### PR TITLE
bug fixes

### DIFF
--- a/source/apps/my_name.my_app.editor.kit
+++ b/source/apps/my_name.my_app.editor.kit
@@ -55,20 +55,29 @@ keywords = ["app", "usd"]
 
 # Viewport Extensions
 #############################################
-# The Main Viewport Window
-"omni.kit.viewport.window" = {}
+# The omni.kit.viewport.bundle extension declares a number
+# viewport extensions as depenencies so you only have
+# to activate the bundle to get the rest. You can
+# comment out the bundle and pick and choose individual
+# viewport extensions.
+"omni.kit.viewport.bundle" = {}
 
-# Selection of Viewport Menu subMenus
-"omni.kit.viewport.menubar.core" = {}
-"omni.kit.viewport.menubar.settings" = {}
-"omni.kit.viewport.menubar.display" = {}
-"omni.kit.viewport.menubar.render" = {}
-"omni.kit.viewport.menubar.camera" = {}
+# The Main Viewport Window (brought in by omni.kit.viewport.bundle)
+# "omni.kit.viewport.window" = {}
 
-# Viewport Manipulator
-"omni.kit.manipulator.prim" = {}
-"omni.kit.manipulator.transform" = {}
-"omni.kit.manipulator.viewport" = {}
+
+# Selection of Viewport Menu subMenus (brought in by omni.kit.viewport.bundle)
+# "omni.kit.viewport.menubar.core" = {}
+# "omni.kit.viewport.menubar.settings" = {}
+# "omni.kit.viewport.menubar.display" = {}
+# "omni.kit.viewport.menubar.render" = {}
+# "omni.kit.viewport.menubar.camera" = {}
+
+# Viewport Manipulator (brought in by omni.kit.viewport.bundle)
+# "omni.kit.manipulator.prim" = {}
+# "omni.kit.manipulator.transform" = {}
+# "omni.kit.manipulator.camera" = {}
+# "omni.kit.manipulator.viewport" = {}
 
 # Additional Viewport features (legacy grid etc, HUD GPU stats)
 "omni.kit.viewport.legacy_gizmos" = {}

--- a/source/apps/my_name.my_app.viewport.kit
+++ b/source/apps/my_name.my_app.viewport.kit
@@ -32,23 +32,29 @@ keywords = ["app"]
 
 # Viewport Extensions
 #############################################
-# The Main Viewport Window
-"omni.kit.viewport.window" = {}
+# The omni.kit.viewport.bundle extension declares a number
+# viewport extensions as depenencies so you only have
+# to activate the bundle to get the rest. You can
+# comment out the bundle and pick and choose individual
+# viewport extensions.
+"omni.kit.viewport.bundle" = {}
 
-# Selection of Viewport Menu subMenus
-# you can disable the one that you don't want to expose here
-# or create your own !!
-"omni.kit.viewport.menubar.settings" = {}
-"omni.kit.viewport.menubar.display" = {}
-"omni.kit.viewport.menubar.render" = {}
-"omni.kit.viewport.menubar.camera" = {}
+# The Main Viewport Window (brought in by omni.kit.viewport.bundle)
+# "omni.kit.viewport.window" = {}
 
-# Viewport Manipulator
-# Same here based on what option you want for your user
-# you can disable some or create your own
-"omni.kit.manipulator.prim" = {}
-"omni.kit.manipulator.transform" = {}
-"omni.kit.manipulator.viewport" = {}
+
+# Selection of Viewport Menu subMenus (brought in by omni.kit.viewport.bundle)
+# "omni.kit.viewport.menubar.core" = {}
+# "omni.kit.viewport.menubar.settings" = {}
+# "omni.kit.viewport.menubar.display" = {}
+# "omni.kit.viewport.menubar.render" = {}
+# "omni.kit.viewport.menubar.camera" = {}
+
+# Viewport Manipulator (brought in by omni.kit.viewport.bundle)
+# "omni.kit.manipulator.prim" = {}
+# "omni.kit.manipulator.transform" = {}
+# "omni.kit.manipulator.camera" = {}
+# "omni.kit.manipulator.viewport" = {}
 
 # Additional Viewport features (legacy grid etc, HUD GPU stats)
 # those display Grids and some HUD, same experiment with or without based on your neeed

--- a/source/extensions/my_name.my_app.setup/my_name/my_app/setup/setup.py
+++ b/source/extensions/my_name.my_app.setup/my_name/my_app/setup/setup.py
@@ -1,16 +1,14 @@
-import omni.ext
-import omni.ui as ui
-from omni.kit.quicklayout import QuickLayout
-import carb.settings
-import carb.tokens
-import omni.kit.menu.utils
-from omni.kit.menu.utils import MenuLayout
-from omni.kit.window.title import get_main_window_title
+import asyncio
+from pathlib import Path
 
 import carb.imgui as _imgui
-
-from pathlib import Path
-import asyncio
+import carb.settings
+import carb.tokens
+import omni.ext
+import omni.kit.menu.utils
+from omni.kit.menu.utils import MenuLayout
+from omni.kit.quicklayout import QuickLayout
+from omni.kit.window.title import get_main_window_title
 
 
 async def _load_layout(layout_file: str):
@@ -77,4 +75,4 @@ class SetupExtension(omni.ext.IExt):
         print("Open the File you want")
 
     def on_shutdown(self):
-        print("[omni.hello.world] MyExtension shutdown")
+        pass

--- a/source/extensions/my_name.my_app.window/my_name/my_app/window/extension.py
+++ b/source/extensions/my_name.my_app.window/my_name/my_app/window/extension.py
@@ -1,6 +1,6 @@
 import omni.ext
 import omni.kit.ui
-# import omni.ui as ui
+
 from .window import MyWindow
 
 
@@ -15,12 +15,12 @@ class WindowExtension(omni.ext.IExt):
         # Most application have an Window Menu, See MenuLayout to re-organize it
         self._window = None
         self._menu = editor_menu.add_item(WindowExtension.MENU_PATH, self._on_menu_click, toggle=True, value=True)
-        self.show_window(self._menu, True)
+        self.show_window(True)
 
     def _on_menu_click(self, menu, toggled):
-        self.show_window(menu, toggled)
+        self.show_window(toggled)
 
-    def show_window(self, menu, toggled):
+    def show_window(self, toggled):
         if toggled:
             if self._window is None:
                 self._window = MyWindow()
@@ -28,12 +28,19 @@ class WindowExtension(omni.ext.IExt):
             else:
                 self._window.show()
         else:
-            self._window = None
+            if self._window is not None:
+                self._window.hide()
 
     def _visiblity_changed_fn(self, visible):
         if self._menu:
             omni.kit.ui.get_editor_menu().set_value(WindowExtension.MENU_PATH, visible)
-            self.show_window(None, visible)
+            self.show_window(visible)
 
     def on_shutdown(self):
-        self._window = None
+        if self._window is not None:
+            self._window.destroy()
+            self._window = None
+        if self._menu is not None:
+            editor_menu = omni.kit.ui.get_editor_menu()
+            editor_menu.remove_item(self._menu)
+            self._menu = None

--- a/source/extensions/my_name.my_app.window/my_name/my_app/window/window.py
+++ b/source/extensions/my_name.my_app.window/my_name/my_app/window/window.py
@@ -29,3 +29,9 @@ class MyWindow(ui.Window):
                 with ui.HStack(height=50, style={"font_size": 24}):
                     ui.Button("Add")
                     ui.Button("Reset")
+
+    def show(self):
+        self.visible = True
+
+    def hide(self):
+        self.visible = False


### PR DESCRIPTION
- Added omni.kit.viewport.bundle to editor and viewport apps and commented out the bundle's dependencies while explain how you could use those instead of bundle.
- Added window destruction to shutdown.
- Fixed visibility toggle for window ext.
- Removed omni.hello.world print from setup ext.
- Import sorting
- Cleanup of unused code.