### PR TITLE
Enable the public registries

### DIFF
--- a/repo.toml
+++ b/repo.toml
@@ -85,9 +85,8 @@ apps = [
 ]
 
 registries = [
-# PUBLIC REGISTRIES - UNCOMMENT BEFORE STAGING TO GITHUB
-    # { name = "kit/default", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/106/shared" },
-    # { name = "kit/sdk", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/sdk/${kit_version_short}/${kit_git_hash}" },
+    { name = "kit/default", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/106/shared" },
+    { name = "kit/sdk", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/sdk/${kit_version_short}/${kit_git_hash}" },
     { name = "kit/community", url = "https://dw290v42wisod.cloudfront.net/exts/kit/community" },
 ]
 


### PR DESCRIPTION
Public registries were not uncommented before staging to GitLab. This change enables the default and sdk public registries for 106.