### PR TITLE
Opting out of lockfile verification so builds will progress.

### DIFF
--- a/templates/apps/kit_base_editor/kit_base_editor.kit
+++ b/templates/apps/kit_base_editor/kit_base_editor.kit
@@ -98,6 +98,9 @@ folders.'++' = [  # Search paths for extensions.
 	"${app}/../extscache/"
 ]
 
+[settings.app.extensions]
+supportedTargets.platform = []
+supportedTargets.config = []
 
 [settings.app.viewport.defaults]
 fillViewport = true  # default to fill viewport

--- a/templates/apps/usd_explorer/omni.usd_explorer.kit
+++ b/templates/apps/usd_explorer/omni.usd_explorer.kit
@@ -133,6 +133,8 @@ generateVersionLockExclude = [
 ]
 registryEnabled = true
 skipPublishVerification = false
+supportedTargets.platform = []
+supportedTargets.config = []
 
 [settings.app.extensions."filter:platform"."linux-x86_64"]
 # Windows only extensions. For all of them set exact=true to not be included into generated version lock.

--- a/templates/apps/usd_viewer/omni.usd_viewer.kit
+++ b/templates/apps/usd_viewer/omni.usd_viewer.kit
@@ -84,6 +84,10 @@ folders.'++' = [  # Search paths for extensions.
     "${app}/../extscache/"
 ]
 
+[settings.app.extensions]
+supportedTargets.platform = []
+supportedTargets.config = []
+
 [settings.app.file]
 ignoreUnsavedOnExit = true  # enable quitting without confirmation
 


### PR DESCRIPTION
Fixes to the .kit template files for USD Explorer, Kit Base Editor, and USD Viewer so that they will continue to build and run even when debug versions of extensions are missing.