### PR TITLE
base_project docs cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Hardened the USD Viewer messaging extension: a missing or empty `paths` payload is now a safe no-op, and exception details are no longer returned to the streaming client
 
-## [110.1.2] - 2026-07-15
-
-### Fixed
-
-- Fixed `repo build` failing after creating a new application from a template (USD Viewer, USD Explorer, Kit Base Editor, or any renamed application) due to a leftover sample-application reference in `premake5.lua` and `repo.toml`. Re-clone or pull the latest `110.1.2` to get the fix.
-
-## [110.1.2] - 2026-07-06
-
-### Fixed
-
-- Fixed an incomplete initial 110.1.2 GitHub publish that could cause first-time setup (`repo template new`) and builds to fail on a fresh clone. Re-clone or pull the latest `110.1.2` / `main` to get the corrected files.
-
 ## [110.1.2] - 2026-06-24
 
 ### Added
@@ -56,7 +44,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - [Kit 110.1.1 Release Notes](https://docs.omniverse.nvidia.com/dev-guide/latest/release-notes/110_1_1.html)
   - [Kit 110.1.1 Release Highlights](https://docs.omniverse.nvidia.com/dev-guide/latest/release-notes/110_1_1_highlights.html)
 - `omni.kit.converter.cad` and `omni.kit.window.modifier.titlebar` cross dependency resolved for target platform check
-
 
 ## [110.1.0] - 2026-04-06
 
@@ -167,7 +154,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed omni.services.transport.server.http.port overrides.  Aligned all template applications to use default ports.
 - Updated repository documentation to reflect changes in streaming changes.
 - Updated crash reporter settings to compress crash reports.
-- Update Windows `omni.kit.window.modifier.titlebar` extension version
+- Update Windows `omni.kit.window.modifier.titlebar` extension version 
 - Update repo tooling to most recent versions
 - Updated application icon images for Composer and Explorer templates
 - Enabled testing for USD Viewer Template messaging extension
@@ -436,3 +423,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Top level build .bat/.sh scripts in favor of using `repo build` directly
 - Predefined `define_app` declarations from `premake5.lua` in favor of developer defined applications
 - Predefined source/apps in favor of templates for developers to build from
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## :memo: Feature Branch Information
 **This repository is based on a Feature Branch of the Omniverse Kit SDK.** Feature Branches are regularly updated and best suited for testing and prototyping.
-For stable, production-oriented development, please use the [Production Branch of the Kit SDK on NVIDIA GPU Cloud (NGC)](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/omniverse/collections/omniverse_enterprise_25h1).
+For stable, production-oriented development, please use the [Production Branch of the Kit SDK on NVIDIA GPU Cloud (NGC)](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/omniverse/collections/omniverse_26h1).
 
 [Omniverse Release Information](https://docs.omniverse.nvidia.com/dev-overview/latest/omniverse-releases.html#)
 
@@ -73,8 +73,6 @@ Ensure your system is set up with the following to work with Omniverse Applicati
 ### Required Software Dependencies
 
 - [**Git**](https://git-scm.com/downloads): For version control and repository management
-
-- [**Git LFS**](https://git-lfs.com/): For managing large files within the repository
 
 - **(Windows - C++ Only) Microsoft Visual Studio (2019 or 2022)**: You can install the latest version from [Visual Studio Downloads](https://visualstudio.microsoft.com/downloads/). Ensure that the **Desktop development with C++** workload is selected.  [Additional information on Windows development configuration](readme-assets/additional-docs/windows_developer_configuration.md)
 
@@ -252,8 +250,6 @@ The Omniverse Platform supports streaming Kit-based applications directly to a w
 
 ### NVIDIA-Managed
 - **NVIDIA Cloud Functions (NVCF):** Offloads hardware, streaming, and network complexities for secure, large scale deployments.
-
-- **Graphics Delivery Network (GDN):** Streams high-fidelity 3D content worldwide with just a shared URL.
 
 [Configuring and packaging streaming-ready Kit applications](readme-assets/additional-docs/kit_app_streaming_config.md)
 

--- a/readme-assets/additional-docs/kit_app_streaming_config.md
+++ b/readme-assets/additional-docs/kit_app_streaming_config.md
@@ -39,15 +39,11 @@ Answer `yes` to enable streaming for your application. You can then pick from th
 ? Browse layers with arrow keys ↑↓: [SPACE to toggle selection, ENTER to confirm selection(s)]
 ❯ [ ] [omni_default_streaming]: Omniverse Kit App Streaming (Default)
   [ ] [nvcf_streaming]: NVCF Streaming
-  [ ] [omni_gdn_streaming]: GDN Streaming
 ```
 
 - **Omniverse Kit App Streaming (Default):** Ideal for self-managed streaming deployments or local streaming during development. Uses [`omni.kit.livestream.webrtc`](https://docs.omniverse.nvidia.com/kit/docs/omni.kit.livestream.webrtc/latest/Overview.html) for WebRTC-based streaming. Choose this for local testing, Kubernetes deployments, or custom infrastructure.
 
 - **NVCF Streaming:** Required for applications deployed on NVIDIA DGX Cloud via NVIDIA Cloud Functions. Adds [`omni.services.livestream.session`](https://docs.omniverse.nvidia.com/kit/docs/omni.services.livestream.session/latest/Overview.html) which implements NVCF-specific health endpoints and session management. See the [DGXC Deployment Guide](dgxc_nvcf_deployment.md) for configuration details.
-
-- **GDN Streaming:** Streams applications through NVIDIA Graphics Delivery Network; especially useful for configurator workflows. Refer to the [End-to-End Configurator Example Guide](https://docs.omniverse.nvidia.com/auto-config/latest/overview.html) for deployment instructions.
-
 
 After creating your application, you'll find two `.kit` files in the `/source/apps/` directory:
 - `{app_name}.kit`: The main application configuration file.
@@ -90,9 +86,6 @@ After you have created and customized your application, build it using the follo
 
   :warning: **Note**
   When prompted to select a `.kit` file, choose the `{app_name}_{streaming_config}.kit` file.
-
-- **GDN Streaming**
-  Refer to the [End-to-End Configurator Example Guide](https://docs.omniverse.nvidia.com/auto-config/latest/overview.html) for instructions on packaging and deploying to NVIDIA GDN.
 
 ## Testing Locally
 


### PR DESCRIPTION
Changes

- Remove the GDN streaming option, the NVIDIA-Managed bullet in README.md, plus the layer-picker option, description bullet, and packaging subsection in readme-assets/additional-docs/kit_app_streaming_config.md.
- Remove the Git LFS prerequisite bullet from README.md. Git LFS is no longer required, and .gitattributes was already clean.
- Update the Feature Branch NGC link from the retired omniverse_enterprise_25h1 collection to omniverse_26h1 (PB 26h1). This is a feature branch, so the note itself stays.
- Backfill CHANGELOG.md, which stopped at 110.1.0, with the 110.1.1, 110.1.2, and 110.2.0 entries to match the published changelog. The 110.1.2 GitHub-publish-incident sub-entries are intentionally omitted from the source.