### PR TITLE
fix: streaming layer example filename inconsistent with template

### DIFF
--- a/readme-assets/additional-docs/kit_app_streaming_config.md
+++ b/readme-assets/additional-docs/kit_app_streaming_config.md
@@ -20,7 +20,7 @@ Choose a template from the options below, then follow the instructions in the te
 An **application layer** is a separate `.kit` configuration file that extends your base application for a specific deployment scenario. Instead of modifying your main application, layers let you create variants optimized for different use cases:
 
 - **Base application** (`my_app.kit`): Your core application with all features and UI
-- **Streaming layer** (`my_app_streaming.kit`): Inherits from base, adds streaming extensions and settings
+- **Streaming layer** (`my_app_{streaming_config}.kit`): Inherits from base, adds streaming extensions and settings
 
 This approach keeps your base application clean while enabling different deployment modes (local desktop, cloud streaming, etc.) from the same codebase.
 


### PR DESCRIPTION
This PR corrects the documentation in `readme-assets/additional-docs/kit_app_streaming_config.md`: streaming layer example filename inconsistent with template.

## Changes
- `readme-assets/additional-docs/kit_app_streaming_config.md`: streaming layer example filename inconsistent with template.

## Details
```diff
--- a/readme-assets/additional-docs/kit_app_streaming_config.md
+++ b/readme-assets/additional-docs/kit_app_streaming_config.md
@@ -1,2 +1,2 @@
-- **Base application** (`my_app.kit`): Your core application with all features and UI
-- **Streaming layer** (`my_app_streaming.kit`): Inherits from base, adds streaming extensions and settings
+- **Base application** (`my_app.kit`): Your core application with all features and UI
+- **Streaming layer** (`my_app_{streaming_config}.kit`): Inherits from base, adds streaming extensions and settings
```

## Tests

> Let me know if you want tests added for this fix or not.