### PR TITLE
fix: Note callout missing trailing colon

### DIFF
--- a/readme-assets/additional-docs/kit_app_streaming_config.md
+++ b/readme-assets/additional-docs/kit_app_streaming_config.md
@@ -84,7 +84,7 @@ After you have created and customized your application, build it using the follo
   ./repo.sh package_container --image-tag [container_image_name:container_image_tag]
   ```
 
-  :warning: **Note**
+  :warning: **Note:**
   When prompted to select a `.kit` file, choose the `{app_name}_{streaming_config}.kit` file.
 
 ## Testing Locally

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,17 @@
+"""Lightweight docs lint checks."""
+import re
+from pathlib import Path
+
+DOCS_ROOT = Path(__file__).resolve().parents[1] / "readme-assets" / "additional-docs"
+
+
+def test_warning_callouts_use_colon():
+    """Warning-style callouts should end with a colon before the body text."""
+    md_file = DOCS_ROOT / "kit_app_streaming_config.md"
+    content = md_file.read_text(encoding="utf-8")
+
+    # Find any ':warning: **Label**' style callout that does not have a colon after it.
+    bad_callouts = re.findall(r":warning:\s*\*\*[A-Za-z ]+?\*\*(?!:)\s*$", content, re.MULTILINE)
+    assert not bad_callouts, (
+        f"Found warning callouts missing trailing colon in {md_file}: {bad_callouts}"
+    )


### PR DESCRIPTION
This PR corrects the documentation in `readme-assets/additional-docs/kit_app_streaming_config.md`: Note callout missing trailing colon.

## Changes
- `readme-assets/additional-docs/kit_app_streaming_config.md`: Note callout missing trailing colon.

## Details
```diff
--- a/readme-assets/additional-docs/kit_app_streaming_config.md
+++ b/readme-assets/additional-docs/kit_app_streaming_config.md
@@ -1,2 +1,2 @@
-  :warning: **Note**
-  When prompted to select a `.kit` file, choose the `{app_name}_{streaming_config}.kit` file.
+  :warning: **Note:**
+  When prompted to select a `.kit` file, choose the `{app_name}_{streaming_config}.kit` file.
```

## Tests
- `tests/test_docs.py`

```diff
--- /dev/null
+++ b/tests/test_docs.py
@@ -0,0 +1,17 @@
+"""Lightweight docs lint checks."""
+import re
+from pathlib import Path
+
+DOCS_ROOT = Path(__file__).resolve().parents[1] / "readme-assets" / "additional-docs"
+
+
+def test_warning_callouts_use_colon():
+    """Warning-style callouts should end with a colon before the body text."""
+    md_file = DOCS_ROOT / "kit_app_streaming_config.md"
+    content = md_file.read_text(encoding="utf-8")
+
+    # Find any ':warning: **Label**' style callout that does not have a colon after it.
+    bad_callouts = re.findall(r":warning:\s*\*\*[A-Za-z ]+?\*\*(?!:)\s*$", content, re.MULTILINE)
+    assert not bad_callouts, (
+        f"Found warning callouts missing trailing colon in {md_file}: {bad_callouts}"
+    )
```