### PR TITLE
fix: extra space before colon in Important callout

### DIFF
--- a/readme-assets/additional-docs/kit_app_streaming_config.md
+++ b/readme-assets/additional-docs/kit_app_streaming_config.md
@@ -4,7 +4,7 @@
 
 Kit SDK templates and tooling enable the creation streaming-ready Omniverse Kit applications and aid in the packaging/containerization in preparation for deployment. This document outlines how to set up, configure, and package Kit applications for a streaming deployment.
 
-:warning: **Important :** Creation of containerized streaming applications must be done from a Linux environment.
+:warning: **Important:** Creation of containerized streaming applications must be done from a Linux environment.
 
 ## Create and Configure an Application
 


### PR DESCRIPTION
This PR corrects the documentation in `readme-assets/additional-docs/kit_app_streaming_config.md`: extra space before colon in Important callout.

## Changes
- `readme-assets/additional-docs/kit_app_streaming_config.md`: extra space before colon in Important callout.

## Details
```diff
--- a/readme-assets/additional-docs/kit_app_streaming_config.md
+++ b/readme-assets/additional-docs/kit_app_streaming_config.md
@@ -1,1 +1,1 @@
-:warning: **Important :** Creation of containerized streaming applications must be done from a Linux environment.
+:warning: **Important:** Creation of containerized streaming applications must be done from a Linux environment.
```

## Tests

> Let me know if you want tests added for this fix or not.